### PR TITLE
fix(backfill): suspend deferred backward tasks durably instead of completing them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,31 @@ check-deps:
 
 # From-source build feature selection.
 # ---------------------------------------------------------------------------
-# The rustpushgo crate's default feature, `cleanroom-registration`, enables
-# `open-absinthe/native-nac-rust` + `remote-clearadi`, which are NOT provided by
-# the upstream OpenBubbles crates this from-source build vendors. So this build
-# opts out of the default and selects the native AAAbsintheContext NAC path
-# (`nac-apple-framework`). omnisette's built-in macOS AOSKit anisette compiles
-# automatically — no provider feature, no unicorn, no cmake. The rustpushgo
-# `anisette-*` features are skipped because they pull `prefer-*` omnisette
-# features that upstream omnisette doesn't define.
+# This Makefile is the macOS-only path (see the Darwin guard above). It opts out
+# of the crate default and selects Apple's native AAAbsintheContext NAC
+# (`nac-apple-framework`), because that is the NAC implementation available on a
+# Mac. omnisette's built-in macOS AOSKit anisette compiles automatically — no
+# provider feature, no unicorn, no cmake.
+#
+# The default feature shape (`cleanroom-registration`) is NOT dead code: it is
+# what Linux builds, since Linux never reaches this Makefile. Do not "clean it
+# up" on the assumption that nothing selects it.
+#
+# An earlier version of this comment claimed the vendored upstream crates do not
+# provide `open-absinthe/native-nac-rust`, `remote-clearadi` or omnisette's
+# `prefer-*` features. That is wrong on all three counts and cost real debugging
+# time, so, as of the pinned SHA:
+#   - omnisette declares `remote-clearadi` and both `prefer-*` features, and
+#     vendors the clearadi crate (apple-private-apis/clearadi).
+#   - rustpush and icloud_auth declare `remote-clearadi`.
+#   - open-absinthe declares `native-nac-rust`, but as an EMPTY placeholder with
+#     zero references in its source — it exists so the feature name resolves.
+#     That is the real reason this build cannot rely on the default shape for
+#     NAC, and it is specific to `native-nac-rust`, not to the others.
+#
+# Note that `--no-default-features` leaves omnisette without its `async` feature
+# (only the `remote-*` features enable it), which makes `omnisette::AnisetteClient`
+# unresolvable. That is why this shape does not build on Linux.
 #
 # Override on the command line to build a different feature shape, e.g.:
 #   make CARGO_FEATURES="--features cleanroom-registration"

--- a/pkg/connector/backfill_state_test.go
+++ b/pkg/connector/backfill_state_test.go
@@ -2,14 +2,55 @@ package connector
 
 import "testing"
 
-func TestBackwardBackfillWaitsForForwardCompletionWithoutRetrying(t *testing.T) {
-	if got := backwardBackfillShouldWaitForForward(false, true); !got {
-		t.Fatal("expected backward backfill to wait while forward backfill is incomplete")
-	}
-	if got := backwardBackfillShouldWaitForForward(true, true); got {
-		t.Fatal("did not expect a wait after forward backfill completed")
-	}
-	if got := backwardBackfillShouldWaitForForward(false, false); got {
-		t.Fatal("did not expect a wait when the portal has no messages")
+func ptrTo[T any](v T) *T { return &v }
+
+// The wait decision is the guard on a permanent write: a backward task that does
+// not wait gets is_done=true, and getNextBackfillQuery never returns a done task
+// again. So every case here is really asking "is it safe to give up on this
+// portal's history forever".
+func TestBackwardBackfillShouldWaitForForward(t *testing.T) {
+	tests := []struct {
+		name        string
+		forwardDone *bool
+		hasMessages bool
+		want        bool
+	}{{
+		name:        "forward incomplete with history waits",
+		forwardDone: ptrTo(false),
+		hasMessages: true,
+		want:        true,
+	}, {
+		name:        "forward complete proceeds to backfill",
+		forwardDone: ptrTo(true),
+		hasMessages: true,
+		want:        false,
+	}, {
+		// An unreadable flag is not evidence forward backfill finished. Waiting
+		// costs a delay that self-heals; not waiting costs the history.
+		name:        "unknown forward state waits",
+		forwardDone: nil,
+		hasMessages: true,
+		want:        true,
+	}, {
+		// Nothing for forward backfill to anchor against, so a wait would never
+		// end — this is the case that must NOT wait.
+		name:        "no messages does not wait even when forward is incomplete",
+		forwardDone: ptrTo(false),
+		hasMessages: false,
+		want:        false,
+	}, {
+		name:        "no messages does not wait when forward state is unknown",
+		forwardDone: nil,
+		hasMessages: false,
+		want:        false,
+	}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backwardBackfillShouldWaitForForward(tt.forwardDone, tt.hasMessages); got != tt.want {
+				t.Fatalf("backwardBackfillShouldWaitForForward(%v, %v) = %v, want %v",
+					tt.forwardDone, tt.hasMessages, got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/connector/backfill_state_test.go
+++ b/pkg/connector/backfill_state_test.go
@@ -1,0 +1,15 @@
+package connector
+
+import "testing"
+
+func TestBackwardBackfillWaitsForForwardCompletionWithoutRetrying(t *testing.T) {
+	if got := backwardBackfillShouldWaitForForward(false, true); !got {
+		t.Fatal("expected backward backfill to wait while forward backfill is incomplete")
+	}
+	if got := backwardBackfillShouldWaitForForward(true, true); got {
+		t.Fatal("did not expect a wait after forward backfill completed")
+	}
+	if got := backwardBackfillShouldWaitForForward(false, false); got {
+		t.Fatal("did not expect a wait when the portal has no messages")
+	}
+}

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -516,6 +516,11 @@ type IMClient struct {
 	// overwhelming CloudKit/Matrix with simultaneous attachment downloads.
 	forwardBackfillSem chan struct{}
 
+	// deferredBackwardBackfills records tasks temporarily completed while a
+	// portal's forward import was still establishing its Matrix anchor.
+	deferredBackwardBackfills   map[string]struct{}
+	deferredBackwardBackfillsMu sync.Mutex
+
 	// attachmentContentCache maps CloudKit record_name → *event.MessageEventContent.
 	// Populated by preUploadCloudAttachments, which runs in the cloud sync
 	// goroutine BEFORE createPortalsFromCloudSync. Checked first by
@@ -7946,6 +7951,54 @@ type cloudBackfillCursor struct {
 	GUID        string `json:"g"`
 }
 
+// backwardBackfillShouldWaitForForward reports whether a backward task should
+// be deferred until the portal's initial forward import has established its
+// Matrix anchor. The task must be re-queued after forward completion rather
+// than returned with HasMore=true and an empty cursor.
+func backwardBackfillShouldWaitForForward(forwardDone, hasMessages bool) bool {
+	return !forwardDone && hasMessages
+}
+
+func (c *IMClient) deferBackwardBackfill(portalID string) {
+	c.deferredBackwardBackfillsMu.Lock()
+	defer c.deferredBackwardBackfillsMu.Unlock()
+	if c.deferredBackwardBackfills == nil {
+		c.deferredBackwardBackfills = make(map[string]struct{})
+	}
+	c.deferredBackwardBackfills[portalID] = struct{}{}
+}
+
+func (c *IMClient) takeDeferredBackwardBackfill(portalID string) bool {
+	c.deferredBackwardBackfillsMu.Lock()
+	defer c.deferredBackwardBackfillsMu.Unlock()
+	if _, ok := c.deferredBackwardBackfills[portalID]; !ok {
+		return false
+	}
+	delete(c.deferredBackwardBackfills, portalID)
+	return true
+}
+
+func (c *IMClient) requeueDeferredBackwardBackfill(ctx context.Context, portalKey networkid.PortalKey) {
+	if !c.takeDeferredBackwardBackfill(string(portalKey.ID)) {
+		return
+	}
+	err := c.Main.Bridge.DB.BackfillTask.Upsert(ctx, &database.BackfillTask{
+		PortalKey:         portalKey,
+		UserLoginID:       c.UserLogin.ID,
+		BatchCount:        -1,
+		IsDone:            false,
+		Cursor:            "",
+		OldestMessageID:   "",
+		NextDispatchMinTS: time.Now().Add(5 * time.Second),
+	})
+	if err != nil {
+		zerolog.Ctx(ctx).Warn().Err(err).Str("portal_id", string(portalKey.ID)).
+			Msg("Failed to requeue backward backfill after forward import")
+		return
+	}
+	c.Main.Bridge.WakeupBackfillQueue()
+}
+
 func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessagesParams) (*bridgev2.FetchMessagesResponse, error) {
 	fetchStart := time.Now()
 	log := zerolog.Ctx(ctx)
@@ -8193,6 +8246,7 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 				readByMe, readErr := cloudStoreDone.getConversationReadByMe(context.Background(), portalID)
 
 				cloudStoreDone.markForwardBackfillDone(context.Background(), portalID)
+				c.requeueDeferredBackwardBackfill(context.Background(), portalKey)
 
 				// NOTE: Receipt 1 (ghost "they read my message") is intentionally
 				// NOT sent during backfill. CloudKit's date_read_ms is unreliable:
@@ -8266,21 +8320,11 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 		// creates an infinite retry loop.
 		if !c.cloudStore.isForwardBackfillDone(ctx, portalID) {
 			hasMessages, _ := c.cloudStore.hasPortalMessages(ctx, portalID)
-			if hasMessages {
+			if backwardBackfillShouldWaitForForward(false, hasMessages) {
+				c.deferBackwardBackfill(portalID)
 				log.Info().Str("portal_id", portalID).
-					Msg("Backward backfill: no anchor yet, forward backfill still in progress — deferring")
-				// Sleep before returning HasMore=true so the bridgev2 backfill
-				// queue doesn't tight-loop on this task and steal scheduler
-				// time from forward backfill (which we're waiting on). Each
-				// tight-loop iteration was ~1s of pure no-op — with 30+
-				// deferred portals, that's 30+ CPU-seconds per second burned
-				// waiting for a state change that takes minutes to happen.
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case <-time.After(30 * time.Second):
-				}
-				return &bridgev2.FetchMessagesResponse{HasMore: true, Forward: false}, nil
+					Msg("Backward backfill: no anchor yet, forward backfill still in progress — completing task until forward import finishes")
+				return &bridgev2.FetchMessagesResponse{HasMore: false, Forward: false}, nil
 			}
 			log.Info().Str("portal_id", portalID).
 				Msg("Backward backfill: no anchor and no messages — stopping (nothing to backfill)")

--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -516,11 +516,6 @@ type IMClient struct {
 	// overwhelming CloudKit/Matrix with simultaneous attachment downloads.
 	forwardBackfillSem chan struct{}
 
-	// deferredBackwardBackfills records tasks temporarily completed while a
-	// portal's forward import was still establishing its Matrix anchor.
-	deferredBackwardBackfills   map[string]struct{}
-	deferredBackwardBackfillsMu sync.Mutex
-
 	// attachmentContentCache maps CloudKit record_name → *event.MessageEventContent.
 	// Populated by preUploadCloudAttachments, which runs in the cloud sync
 	// goroutine BEFORE createPortalsFromCloudSync. Checked first by
@@ -7951,49 +7946,76 @@ type cloudBackfillCursor struct {
 	GUID        string `json:"g"`
 }
 
-// backwardBackfillShouldWaitForForward reports whether a backward task should
-// be deferred until the portal's initial forward import has established its
-// Matrix anchor. The task must be re-queued after forward completion rather
-// than returned with HasMore=true and an empty cursor.
-func backwardBackfillShouldWaitForForward(forwardDone, hasMessages bool) bool {
-	return !forwardDone && hasMessages
-}
-
-func (c *IMClient) deferBackwardBackfill(portalID string) {
-	c.deferredBackwardBackfillsMu.Lock()
-	defer c.deferredBackwardBackfillsMu.Unlock()
-	if c.deferredBackwardBackfills == nil {
-		c.deferredBackwardBackfills = make(map[string]struct{})
-	}
-	c.deferredBackwardBackfills[portalID] = struct{}{}
-}
-
-func (c *IMClient) takeDeferredBackwardBackfill(portalID string) bool {
-	c.deferredBackwardBackfillsMu.Lock()
-	defer c.deferredBackwardBackfillsMu.Unlock()
-	if _, ok := c.deferredBackwardBackfills[portalID]; !ok {
+// backwardBackfillShouldWaitForForward reports whether a backward task must be
+// suspended until the portal's initial forward import has established its Matrix
+// anchor.
+//
+// forwardDone is tri-state on purpose. The flag lives in SQLite (cloud_chat.
+// fwd_backfill_done), and a read of it can fail — under exactly the write
+// contention a large backfill produces. An unknown answer must not be collapsed
+// into "not done": that would suspend a portal whose forward import already
+// finished, and it must not be collapsed into "done" either, which would drop
+// the task's only anchor guard. Callers pass nil for unknown and get a wait,
+// which is recoverable, rather than a guess.
+func backwardBackfillShouldWaitForForward(forwardDone *bool, hasMessages bool) bool {
+	if !hasMessages {
+		// Nothing for a forward import to anchor against, so waiting can only
+		// suspend the task forever.
 		return false
 	}
-	delete(c.deferredBackwardBackfills, portalID)
-	return true
+	return forwardDone == nil || !*forwardDone
 }
 
-func (c *IMClient) requeueDeferredBackwardBackfill(ctx context.Context, portalKey networkid.PortalKey) {
-	if !c.takeDeferredBackwardBackfill(string(portalKey.ID)) {
+// pullForwardBackwardBackfillQuery moves a suspended backward task's next
+// dispatch earlier. It is deliberately not BackfillTaskQuery.Upsert/Update:
+// those write every column from a struct the caller assembled, which would
+// clobber a cursor, batch count or done flag that the queue advanced
+// independently — and both are read-modify-write against a row bridgev2 also
+// writes from the queue goroutine.
+//
+// The guards make the statement safe to run at any moment:
+//   - is_done/queue_done false: never resurrect a task that legitimately finished.
+//   - next_dispatch_min_ts > new value: only ever move dispatch EARLIER. A task
+//     already scheduled sooner (or mid-batch, where MarkDispatched has parked it
+//     an hour out and the queue owns the row) is left alone.
+//
+// Nothing here is load-bearing for correctness. If this update is lost to a
+// race with the queue's own trailing Update, the task keeps the 24h suspension
+// bridgev2 gave it and recovers on its own — later than ideal, never never.
+const pullForwardBackwardBackfillQuery = `
+	UPDATE backfill_task
+	SET next_dispatch_min_ts = $4
+	WHERE bridge_id = $1 AND portal_id = $2 AND portal_receiver = $3
+	  AND is_done = false AND queue_done = false
+	  AND next_dispatch_min_ts > $4
+`
+
+// wakeBackwardBackfillAfterForward un-suspends the backward task for a portal
+// whose forward import just landed.
+//
+// This is an optimization over the 24h retry bridgev2 schedules for a pending
+// task, not the mechanism that makes deferral work. That distinction is the
+// whole point: an earlier version tracked deferred portals in an in-memory map
+// and returned HasMore=false, which made bridgev2 persist is_done=true
+// (portalbackfill.go:156) and left this callback as the ONLY path back. Since
+// getNextBackfillQuery filters on is_done=false and nothing calls MarkNotDone at
+// startup, any missed callback — a crash, a room-send failure before
+// CompleteCallback runs, a lost update from the queue's trailing Update — cost
+// that portal its entire history, permanently and silently.
+func (c *IMClient) wakeBackwardBackfillAfterForward(ctx context.Context, portalKey networkid.PortalKey) {
+	dispatchAt := time.Now().Add(5 * time.Second)
+	res, err := c.Main.Bridge.DB.Exec(ctx, pullForwardBackwardBackfillQuery,
+		c.Main.Bridge.DB.BridgeID, portalKey.ID, portalKey.Receiver, dispatchAt.UnixNano(),
+	)
+	if err != nil {
+		// Warn, not error: the task is still queued with its own retry.
+		zerolog.Ctx(ctx).Warn().Err(err).Str("portal_id", string(portalKey.ID)).
+			Msg("Failed to bring backward backfill forward after forward import (task will retry on its own)")
 		return
 	}
-	err := c.Main.Bridge.DB.BackfillTask.Upsert(ctx, &database.BackfillTask{
-		PortalKey:         portalKey,
-		UserLoginID:       c.UserLogin.ID,
-		BatchCount:        -1,
-		IsDone:            false,
-		Cursor:            "",
-		OldestMessageID:   "",
-		NextDispatchMinTS: time.Now().Add(5 * time.Second),
-	})
-	if err != nil {
-		zerolog.Ctx(ctx).Warn().Err(err).Str("portal_id", string(portalKey.ID)).
-			Msg("Failed to requeue backward backfill after forward import")
+	if rows, _ := res.RowsAffected(); rows == 0 {
+		// Normal: the portal had no suspended backward task, or the queue is
+		// already working it.
 		return
 	}
 	c.Main.Bridge.WakeupBackfillQueue()
@@ -8205,6 +8227,11 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 			// Use context.Background() — if the bridge is shutting down, ctx
 			// may be cancelled but we still need to persist the flag.
 			c.cloudStore.markForwardBackfillDone(context.Background(), portalID)
+			// Reachable with a suspended backward task waiting on this portal:
+			// hasPortalMessages counts raw cloud_message rows, and conversion can
+			// still drop every one of them. There is no CompleteCallback on this
+			// path, so wake the backward task here or it sits out the full 24h.
+			c.wakeBackwardBackfillAfterForward(context.Background(), params.Portal.PortalKey)
 			return &bridgev2.FetchMessagesResponse{HasMore: false, Forward: true}, nil
 		}
 
@@ -8246,7 +8273,7 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 				readByMe, readErr := cloudStoreDone.getConversationReadByMe(context.Background(), portalID)
 
 				cloudStoreDone.markForwardBackfillDone(context.Background(), portalID)
-				c.requeueDeferredBackwardBackfill(context.Background(), portalKey)
+				c.wakeBackwardBackfillAfterForward(context.Background(), portalKey)
 
 				// NOTE: Receipt 1 (ghost "they read my message") is intentionally
 				// NOT sent during backfill. CloudKit's date_read_ms is unreliable:
@@ -8318,13 +8345,32 @@ func (c *IMClient) FetchMessages(ctx context.Context, params bridgev2.FetchMessa
 		// But if the portal has no messages at all, stop waiting — there's
 		// nothing for forward backfill to anchor against, and deferring
 		// creates an infinite retry loop.
-		if !c.cloudStore.isForwardBackfillDone(ctx, portalID) {
-			hasMessages, _ := c.cloudStore.hasPortalMessages(ctx, portalID)
-			if backwardBackfillShouldWaitForForward(false, hasMessages) {
-				c.deferBackwardBackfill(portalID)
+		forwardDone, forwardErr := c.cloudStore.checkForwardBackfillDone(ctx, portalID)
+		if forwardErr != nil || !forwardDone {
+			hasMessages, msgErr := c.cloudStore.hasPortalMessages(ctx, portalID)
+			if msgErr != nil {
+				// Unknown, so assume there is history to protect. The opposite
+				// default sends this task down the "nothing to backfill" path
+				// below, which is permanent — one transient SQLite error would
+				// cost the portal its history.
+				hasMessages = true
+			}
+			var forwardDoneRead *bool
+			if forwardErr == nil {
+				forwardDoneRead = &forwardDone
+			}
+			if backwardBackfillShouldWaitForForward(forwardDoneRead, hasMessages) {
 				log.Info().Str("portal_id", portalID).
-					Msg("Backward backfill: no anchor yet, forward backfill still in progress — completing task until forward import finishes")
-				return &bridgev2.FetchMessagesResponse{HasMore: false, Forward: false}, nil
+					AnErr("forward_state_err", forwardErr).
+					AnErr("message_check_err", msgErr).
+					Msg("Backward backfill: no anchor yet, forward backfill still in progress — suspending task until forward import finishes")
+				// Pending, not HasMore=false. bridgev2 parks a pending task for
+				// 24h with is_done/queue_done untouched (portalbackfill.go:135),
+				// so the suspension survives a restart and self-heals even if
+				// the forward CompleteCallback never runs. HasMore=false would
+				// instead persist is_done=true, which nothing reverses.
+				// wakeBackwardBackfillAfterForward normally cuts the 24h to ~5s.
+				return &bridgev2.FetchMessagesResponse{Pending: true, Forward: false}, nil
 			}
 			log.Info().Str("portal_id", portalID).
 				Msg("Backward backfill: no anchor and no messages — stopping (nothing to backfill)")

--- a/pkg/connector/cloud_backfill_store.go
+++ b/pkg/connector/cloud_backfill_store.go
@@ -3490,19 +3490,33 @@ func (s *cloudBackfillStore) markForwardBackfillDone(ctx context.Context, portal
 	}
 }
 
-// isForwardBackfillDone returns true if forward backfill has completed for the
-// given portal. Used by backward backfill to avoid permanently marking
-// is_done=true before forward backfill has inserted the anchor message.
-func (s *cloudBackfillStore) isForwardBackfillDone(ctx context.Context, portalID string) bool {
+// checkForwardBackfillDone reports whether forward backfill has completed for
+// the given portal, keeping a failed read distinguishable from a negative one.
+//
+// Backward backfill needs that distinction: it uses this flag to decide whether
+// marking a task done is safe, and "the query failed" is not evidence either
+// way. See backwardBackfillShouldWaitForForward.
+func (s *cloudBackfillStore) checkForwardBackfillDone(ctx context.Context, portalID string) (bool, error) {
 	var done bool
 	err := s.db.QueryRow(ctx,
 		`SELECT EXISTS(SELECT 1 FROM cloud_chat WHERE login_id=$1 AND portal_id=$2 AND fwd_backfill_done=TRUE)`,
 		s.loginID, portalID,
 	).Scan(&done)
 	if err != nil {
-		return false
+		return false, err
 	}
-	return done
+	return done, nil
+}
+
+// isForwardBackfillDone returns true if forward backfill has completed for the
+// given portal. Used by backward backfill to avoid permanently marking
+// is_done=true before forward backfill has inserted the anchor message.
+//
+// Reports false on a failed read. Only call this where treating an error as
+// "not done" is the safe direction; otherwise use checkForwardBackfillDone.
+func (s *cloudBackfillStore) isForwardBackfillDone(ctx context.Context, portalID string) bool {
+	done, err := s.checkForwardBackfillDone(ctx, portalID)
+	return err == nil && done
 }
 
 // getForwardBackfillDonePortals returns the set of portal IDs whose forward

--- a/pkg/rustpushgo/Cargo.toml
+++ b/pkg/rustpushgo/Cargo.toml
@@ -19,6 +19,16 @@ name = "rustpushgo"
 #   key_establishment/sign; no unicorn or Apple framework required)
 # - ADI/anisette: omnisette + icloud_auth remote-clearadi (ClearADIClient backed
 #   by the clearadi crate's portable ProvisioningSession + gen_otp)
+#
+# Caveat against the currently pinned upstream: the ADI/anisette half above is
+# real (omnisette declares remote-clearadi and vendors apple-private-apis/
+# clearadi), but `open-absinthe/native-nac-rust` is an EMPTY placeholder feature
+# with zero references in open-absinthe's source. So this shape compiles and
+# gives clean-room ADI, but the pure-Rust NAC it names is not present in the
+# vendored tree. Verify before treating a default build as fully clean-room.
+#
+# This IS the Linux build shape. The Makefile overrides it, but the Makefile is
+# macOS-only (it hard-errors on non-Darwin), so nothing else selects it.
 default = ["cleanroom-registration"]
 cleanroom-registration = [
     "open-absinthe/native-nac-rust",

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -60,20 +60,8 @@ fn bridge_default_provider(
     path: PathBuf,
     device_id: String,
 ) -> omnisette::ArcAnisetteClient<BridgeDefaultAnisetteProvider> {
-    // The omnisette provider selected with `cleanroom-registration` takes a
-    // `device_id`; upstream OpenBubbles omnisette's `default_provider` is 2-arg.
-    // Gate on the feature so both signatures build: with cleanroom-registration
-    // the 3-arg call is used; without it (this from-source build) the 2-arg
-    // upstream signature is used.
-    #[cfg(feature = "cleanroom-registration")]
-    {
-        omnisette::default_provider(info, path, device_id)
-    }
-    #[cfg(not(feature = "cleanroom-registration"))]
-    {
-        let _ = device_id;
-        omnisette::default_provider(info, path)
-    }
+    let _ = device_id;
+    omnisette::default_provider(info, path)
 }
 #[cfg(all(not(target_os = "macos"), feature = "anisette-remote-v3"))]
 fn bridge_default_provider(

--- a/pkg/rustpushgo/src/lib.rs
+++ b/pkg/rustpushgo/src/lib.rs
@@ -54,6 +54,25 @@ pub type BridgeDefaultAnisetteProvider = omnisette::DefaultAnisetteProvider;
 #[cfg(all(not(target_os = "macos"), feature = "anisette-remote-v3"))]
 pub type BridgeDefaultAnisetteProvider = anisette::BridgeAnisetteProvider;
 
+// `omnisette::default_provider` is 2-arg in EVERY cfg variant the vendored
+// omnisette defines (apple-private-apis/omnisette/src/lib.rs: :86
+// remote-anisette-v3, :97 remote-clearadi, :125 macOS AOSKit). There is no
+// 3-arg variant in this tree to be compatible with.
+//
+// A previous version gated this call on `cleanroom-registration` and passed a
+// third `device_id` there, on the belief that the clean-room omnisette takes
+// one. It does not: `cleanroom-registration` pulls `omnisette/remote-clearadi`,
+// which on non-macOS selects the ClearADIClient variant at :97 — 2-arg — so the
+// gated call could not compile under the crate's own default features. That is
+// the Linux build (the Makefile is macOS-only), so the gate broke exactly the
+// shape it was meant to serve.
+//
+// Keep this 2-arg. If a 3-arg provider is ever vendored, reintroduce the gate
+// with a compile check for BOTH shapes rather than restoring it from memory.
+//
+// `device_id` is accepted but unused: both cfg variants of this function ignore
+// it, and it is retained only so the two call sites (which do hold a device
+// UUID) keep a stable signature if provider selection changes.
 #[cfg(any(target_os = "macos", not(feature = "anisette-remote-v3")))]
 fn bridge_default_provider(
     info: omnisette::LoginClientInfo,


### PR DESCRIPTION
## Problem

With ~2k backfill tasks queued, backward tasks for portals whose forward import had not yet landed a Matrix anchor logged this on a loop:

```
message_count=0  has_more=true  new_cursor=  is_done=false
```

Each cycle re-ran the same task without advancing history, adding SQLite write contention that slowed the forward imports the backward tasks were waiting on.

## Approach

A backward task with no cursor and no anchor, on a portal that has CloudKit rows and an incomplete forward import, now returns `FetchMessagesResponse.Pending`.

bridgev2 parks a pending task for 24h with `is_done` and `queue_done` untouched (`portalbackfill.go:135`), so the suspension is persisted in SQLite and survives a restart. When the forward import completes, one guarded `UPDATE` brings the task's `next_dispatch_min_ts` forward to ~5s and wakes the queue, so the 24h floor is a fallback rather than the normal wait.

## Why not complete the task and re-create it

The first version of this PR returned `HasMore=false` and tracked the portal in an in-memory map for the forward `CompleteCallback` to re-queue. That is unsafe: `HasMore=false` makes bridgev2 persist `is_done=true` and `queue_done=true` (`portalbackfill.go:156`), `getNextBackfillQuery` filters both to false, and nothing calls `MarkNotDone` at startup. The write is permanent, which made the in-memory map the only path back, with three ways to lose a portal's entire history silently:

- Process exit between the task being marked done and the callback firing.
- `DoBackfillTask`'s trailing `BackfillTask.Update` runs after the portal backfill lock is released, with `is_done` already true in its stale struct — a callback landing in that window is overwritten.
- The forward-done flag was read before the map insert, so a forward import completing in between found an empty map and left the entry orphaned.

`Pending` removes the class: the durable state is never "done", so a missed wake-up costs a delay that self-heals, never the history. The map, its mutex and both accessors are deleted rather than fixed — which also removes a portal-key collision, since the map was keyed on portal ID without the login receiver.

## Wake-up is an optimization, not the mechanism

Forward completion runs a single guarded statement rather than `BackfillTask.Upsert`:

```sql
UPDATE backfill_task SET next_dispatch_min_ts = $4
WHERE bridge_id = $1 AND portal_id = $2 AND portal_receiver = $3
  AND is_done = false AND queue_done = false
  AND next_dispatch_min_ts > $4
```

`Upsert` writes every column from a caller-assembled struct, which reset the cursor, batch count and `queue_done` of a task that had progressed independently, and is read-modify-write against a row the queue goroutine also writes. The statement above touches one column, refuses to resurrect a finished task, and can only move dispatch earlier. Losing it to a race with the queue's trailing `Update` leaves the 24h suspension in place.

The forward path that returns no messages also wakes the task now. It marks forward done but has no `CompleteCallback`, and it is reachable — `hasPortalMessages` counts raw `cloud_message` rows while conversion can still drop all of them.

## Failed reads no longer mark tasks done

`checkForwardBackfillDone` returns `(bool, error)`; `backwardBackfillShouldWaitForForward` takes `*bool` and waits on nil. A `hasPortalMessages` error is treated as "history exists".

Both previously collapsed a failed read into the answer that marks the task done, so a single transient SQLite error — under exactly the write contention this PR addresses — cost a portal its history.

## Build compatibility

`bridge_default_provider` previously gated its call on `cleanroom-registration` and passed a third `device_id` argument there. It now always calls the 2-arg `omnisette::default_provider`.

Measured on the pinned upstream SHA, on Linux:

| feature shape | result |
| --- | --- |
| `cargo check --lib` (default = `cleanroom-registration`) | **passes** |
| `cargo check --lib --no-default-features --features nac-apple-framework` | **fails** — `unresolved import omnisette::AnisetteClient` |

The second shape is the Makefile's, and the Makefile hard-errors on non-Darwin (`Makefile:49`), so it is macOS-only. The crate default is the Linux build shape.

That is what makes the old gate wrong rather than merely redundant: `cleanroom-registration` pulls `omnisette/remote-clearadi`, which on non-macOS selects the `ClearADIClient` variant of `default_provider` — 2-arg, like every other variant in that file (`:86`, `:97`, `:125`). The gate's 3-arg branch could not compile under the crate's own default features, i.e. it broke precisely the portable Linux build it was meant to serve. There is no 3-arg provider anywhere in the vendored tree, so removing the gate loses no compatibility.

The second-shape failure is unrelated to this change and pre-existing: `rustpushgo` declares omnisette with `default-features = false`, and omnisette gates `AnisetteClient` behind its `async` feature, which only the `remote-*` features enable.

A follow-up commit corrects three comments that asserted the opposite of the above — most consequentially the Makefile's claim that the vendored crates do not provide `remote-clearadi` or the `prefer-*` features. They do. Only `open-absinthe/native-nac-rust` is absent in substance, and it is declared as an empty placeholder with zero references in open-absinthe's source, which is the actual reason this build cannot source NAC from the default shape. `Cargo.toml` now carries that caveat, so a default build is not assumed to be fully clean-room.

## Verification

All run with `CGO_LDFLAGS="-lz"`. The link failure that previously blocked the test suite was a missing `-lz`, not a missing Rust/FFI environment — so the "full connector tests were not run" caveat from earlier revisions of this description no longer applies.

- `go vet ./pkg/connector` passes.
- `go build ./...` passes.
- `go test ./...` passes — `imessage`, `pkg/cli`, `pkg/connector`, `pkg/imconfig`. The full connector suite runs in ~7s.
- `cargo check --lib` (default features) passes on Linux; remaining warnings are pre-existing lint noise.
- Smoke test confirms invalid hardware-key input reaches the parser rather than returning hardware-key-unavailable.

Not covered: the macOS build shape. The Makefile hard-errors on non-Darwin, so `--no-default-features --features nac-apple-framework` could not be exercised here and needs a Mac to confirm. Nothing in this PR is macOS-specific, but the Rust wrapper change is on a shared code path.

Also not covered: runtime behaviour. The `Pending` path has not been observed against a live backfill queue — see below.

Production was rolled back to the known-good 1.1.0 image; this PR is not deployed.

## Known gaps

**Not exercised at runtime.** Every claim here is from source reading, unit tests and compilation. The `Pending` suspension and the wake-up `UPDATE` have not been watched against a live queue with real contention. The specific thing to confirm on first deploy: backward tasks for anchor-less portals should log `suspending task until forward import finishes` once and then go quiet, rather than reappearing every cycle, and each should come back within seconds of its portal's forward import completing — not 24h later. A 24h gap means the wake-up is not landing and the fallback is carrying it.

**The "no anchor and no messages" path still persists `is_done=true`.** Pre-existing and untouched: if CloudKit rows arrive for that portal later, the task does not come back. Converting it to `Pending` would risk suspending genuinely empty portals in a 24h loop indefinitely, so it is left for a separate change.

**Backfill is not resumed for portals already marked done.** This PR stops the bug from marking any more tasks permanently done, but adds no reconciliation for rows already in that state. The buggy revision was never deployed and the pre-PR behaviour was a retry loop rather than a done-write, so there should be nothing to repair — worth a query against the production DB before assuming so.

