### PR TITLE
fix(management-room): give the user full power in the auto-created room

### DIFF
--- a/pkg/connector/client.go
+++ b/pkg/connector/client.go
@@ -1500,7 +1500,16 @@ func (c *IMClient) Connect(ctx context.Context) {
 	// Run in a goroutine to avoid blocking Connect on the homeserver round-trip.
 	go c.ensureBotPushRuleSilenced(ctx)
 
-	go c.maybeSendManagementRoomWelcome(context.Background(), log)
+	go func() {
+		mgmtCtx := context.Background()
+		// Sequential, not a second goroutine: the welcome is the only thing that
+		// creates the room, and it repairs the room it creates. The second call
+		// is the self-heal for installs that were welcomed by an older build —
+		// there the welcome short-circuits on WelcomeSent and never resolves a
+		// room at all. It re-reads the levels and no-ops once they're right.
+		c.maybeSendManagementRoomWelcome(mgmtCtx, log)
+		c.repairManagementRoomPowerLevel(mgmtCtx, c.UserLogin.User.ManagementRoom, log)
+	}()
 
 	// Set up contact source: external CardDAV > local macOS > iCloud CardDAV
 	if c.Main.Config.CardDAV.IsConfigured() {
@@ -1606,6 +1615,12 @@ func (c *IMClient) maybeSendManagementRoomWelcome(ctx context.Context, log zerol
 		log.Warn().Err(err).Msg("Welcome: failed to get management room")
 		return
 	}
+	// Repair before the welcome, not after: in a brand-new room the power-level
+	// event then lands adjacent to the creation events, where clients fold it
+	// into the "created and configured the room" summary, and the intro message
+	// stays the last thing in the timeline.
+	c.repairManagementRoomPowerLevel(ctx, mgmtRoom, log)
+
 	prefix := c.Main.Bridge.Config.CommandPrefix
 	markdown := fmt.Sprintf(managementRoomWelcomeMarkdown, prefix)
 	content := format.RenderMarkdown(markdown, true, false)
@@ -1653,6 +1668,53 @@ You're signed in. This is your **management room** — the bot uses it to delive
 
 Run ` + "`help`" + ` any time for the full command list.
 `
+
+// managementRoomUserPowerLevel is the level the user gets in their own
+// management room: the createRoom creator default, i.e. exactly what they'd
+// have if they had made the room themselves by DMing the bot.
+const managementRoomUserPowerLevel = 100
+
+// repairManagementRoomPowerLevel raises the user to full power in their
+// management room.
+//
+// bridgev2 auto-creates that room as the bot and hands the user power level 50
+// (user.go GetManagementRoom's PowerLevelOverride). 50 is below the createRoom
+// default of 100 for m.room.power_levels, m.room.tombstone and
+// m.room.encryption, so the user is a guest with limited rights in what is
+// nominally their own room and client-side clean-up flows that touch room state
+// fail against it. A management room the user made themselves — by DMing the
+// bot — puts them at 100 for free; this makes the auto-created one match.
+//
+// Runs on every connect, so it also heals rooms created by older builds.
+// Management room only: portal rooms keep the locked-down levels from
+// hardenedPowerLevels, and since the management room is not a portal, the
+// resetEscalatedUsers rubberband never runs against it and can't undo this.
+// Best-effort — every failure is logged and swallowed.
+func (c *IMClient) repairManagementRoomPowerLevel(ctx context.Context, roomID id.RoomID, log zerolog.Logger) {
+	if roomID == "" {
+		return
+	}
+	log = log.With().Str("management_room", string(roomID)).Logger()
+	pl, err := c.Main.Bridge.Matrix.GetPowerLevels(ctx, roomID)
+	if err != nil {
+		log.Warn().Err(err).Msg("Management room: failed to read power levels")
+		return
+	}
+	userMXID := c.UserLogin.User.MXID
+	if pl.GetUserLevel(userMXID) >= managementRoomUserPowerLevel {
+		// Already fine: a user-created room, or one an earlier connect repaired.
+		return
+	}
+	if !pl.EnsureUserLevelAs(c.Main.Bridge.Bot.GetMXID(), userMXID, managementRoomUserPowerLevel) {
+		log.Warn().Msg("Management room: bot cannot raise the user's power level")
+		return
+	}
+	if _, err = c.Main.Bridge.Bot.SendState(ctx, roomID, event.StatePowerLevels, "", &event.Content{Parsed: pl}, time.Time{}); err != nil {
+		log.Warn().Err(err).Msg("Management room: failed to apply repaired power levels")
+		return
+	}
+	log.Info().Int("power_level", managementRoomUserPowerLevel).Msg("Management room: raised the user to full power")
+}
 
 func (c *IMClient) Disconnect() {
 	// bridgev2 serializes its own Disconnect calls (disconnectOnce), but


### PR DESCRIPTION
## The bug

The management room bridgev2 auto-creates when the bridge is first started — the one that comes up with the welcome notice — leaves the user at power level 50.

bridgev2 creates it as the bot and hands the user a `PowerLevelOverride` of `{bot: 9001, user: 50}` (`bridgev2/user.go:226`). 50 sits below the createRoom default of 100 for `m.room.power_levels`, `m.room.tombstone`, `m.room.encryption` and `m.room.history_visibility`, so the user is a guest with limited rights in what is nominally their own room.

A management room the user makes themselves, by DMing the bridge bot, puts them at 100 for free because they are the room's creator (`bridgev2/matrixinvite.go:43` just adopts it). This makes the auto-created one match.

## The fix

`repairManagementRoomPowerLevel` runs on every `Connect()`: read the room's power levels, and if the user is below 100, have the bot send a corrected `m.room.power_levels`. The bot sits at 9001, so it clears both `EnsureUserLevelAs` gates and the 100 needed to send the event.

It is both halves of the fix:

- **At creation** — fires inside the welcome path, between room creation and the welcome post, so a fresh room is correct before the user ever sees it.
- **Self-heal** — the connect-time pass reaches rooms created by older builds, where the welcome short-circuits on `WelcomeSent` and never resolves a room at all. Existing installs correct themselves on the first restart after updating, with no user action.

Idempotent: once the user is at 100 (or is the room's creator, where `GetUserLevel` returns `math.MaxInt`) it returns before sending anything. It reads `User.ManagementRoom` directly rather than calling `GetManagementRoom`, so a background repair can never conjure a room into existence. Best-effort throughout — a room the bot can't read is logged and skipped, never fatal.

## Cosmetic noise

On a fresh login the repair fires before the welcome post, so the power-level event lands adjacent to the creation events where clients fold it into the "created and configured the room" summary, and the intro message stays last in the timeline.

Existing rooms take exactly one visible `m.room.power_levels` event, once, on the next restart. That is unavoidable — a power-level change is a state event by definition — and it never fires again.

## Scope

**Management room only.** Portal rooms keep the locked-down levels from `hardenedPowerLevels`; a Matrix user must not be able to overrule the bridge bot in a bridged chat, and nothing here touches that path. Since the management room is not a portal, the `resetEscalatedUsers` rubberband never runs against it and cannot undo this either.

Re-sending the fetched power-level content is lossless: `CreateEvent` is `json:"-"` (`event/powerlevels.go:41`), so only the user's entry in `users` changes.

## Known gap

The repair is connect-time. A management room bridgev2 auto-creates mid-session — an empty pointer plus a notice, e.g. `bridgestate.go:144` on a transient disconnect — is born at 50 and heals on the next restart rather than immediately. Closing that fully would need every `GetManagementRoom` call site routed through a repairing wrapper, and bridgev2's own call site is out of reach without forking mautrix, so it would still be partial.

## Note on the original report

This was reported as "the auto-created management room can't be deleted or archived." The power-level asymmetry above is real and worth fixing on its own terms, but it is probably **not** what blocks deletion:

- Leaving, forgetting and archiving (`m.tag` / `com.beeper.inbox.done`) are never power-gated.
- Beeper's delete is `com.beeper.delete_chat`, a **message** event (`event/type.go:247`), so `events_default: 0` — sendable at PL 50. It is only acted on inside `Portal.handleMatrixDeleteChat` (`portal.go:1930`), and every event in the management room hits an early return at `bridgev2/queue.go:126` before `GetPortalByMXID`. The request is swallowed and returns Success.

Discriminator: run `set-management-room` in a DM you created yourself. That moves the pointer, so the old room stops matching `evt.RoomID == sender.ManagementRoom` and stops being swallowed. If it becomes deletable the instant it is no longer the management room, the swallow is confirmed.

## Testing

`go build` and `go vet` clean; `go test ./pkg/connector/` passes. Not yet exercised against a live homeserver — the first real proof is `Management room: raised the user to full power` in the logs after a restart.

https://claude.ai/code/session_01S3iBKg2uWPWxP7jFsgJd3t
